### PR TITLE
Vim shouldn't be in upper case

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@ refactorings are available in this IDE. We feel there are several reasons to hav
 such a tool in PHP natively:</p>
 
 <ul>
-<li>We are VIM users and don't want to use an IDE for refactorings. Also we
+<li>We are Vim users and don't want to use an IDE for refactorings. Also we
 are independent of an IDE and users of any (non PHP Storm) editor can now
 benefit from the practice of automated refactorings.</li>
 <li>The non-existance of a simple refactoring tool leads to programmers not


### PR DESCRIPTION
I just wanted to ucfirst() that usage of "VIM" for you. Minor stuff, I know, but hopefully still welcome. Love the tool by the way. UNIX-as-IDE just got a little better.
