### PR TITLE
Fix the including of composers autoloader so as to handle being a dep.

### DIFF
--- a/src/bin/compile
+++ b/src/bin/compile
@@ -1,7 +1,9 @@
 #!/usr/bin/env php
 <?php
 
-require __DIR__.'/../../vendor/autoload.php';
+if ((!@include __DIR__ . '/../../../../autoload.php') && (!@include __DIR__ . '/../../vendor/autoload.php')) {
+    die("You must set up the project dependencies, run composer install");
+}
 
 use QafooLabs\Refactoring\Adapters\Symfony\Compiler;
 

--- a/src/bin/refactor
+++ b/src/bin/refactor
@@ -1,10 +1,11 @@
 #!/usr/bin/env php
 <?php
 
-use QafooLabs\Refactoring\Adapters\Symfony\CliApplication;
+if ((!@include __DIR__ . '/../../../../autoload.php') && (!@include __DIR__ . '/../../vendor/autoload.php')) {
+    die("You must set up the project dependencies, run composer install");
+}
 
-require_once __DIR__ . "/../../vendor/autoload.php";
+use QafooLabs\Refactoring\Adapters\Symfony\CliApplication;
 
 $application = new CliApplication();
 $application->run();
-


### PR DESCRIPTION
Currently, the call to require assumes that we are running php-refactoring-browser stand alone.

This fix enables the project to be included as a dependency of another.
