### PR TITLE
Fixed with ending with a single blank line

### DIFF
--- a/src/main/QafooLabs/Patches/PatchBuilder.php
+++ b/src/main/QafooLabs/Patches/PatchBuilder.php
@@ -53,7 +53,7 @@ class PatchBuilder
     public function __construct($contents, $path = null)
     {
         if ( ! empty($contents)) {
-            $this->lines = explode("\n", $contents);
+            $this->lines = explode("\n", rtrim($contents));
         }
         $this->path = $path;
     }

--- a/src/test/QafooLabs/Patches/PatchBuilderTest.php
+++ b/src/test/QafooLabs/Patches/PatchBuilderTest.php
@@ -136,4 +136,34 @@ DIFF
 DIFF
             , $builder->generateUnifiedDiff());
     }
+
+    public function testAppendLineAtEndWithoutSingleBlankLine()
+    {
+        $builder = new PatchBuilder("foo\nfoo\nbar\nbaz\nbaz");
+        $builder->appendToLine(5, array("boing"));
+
+        $this->assertEquals(<<<DIFF
+@@ -3,3 +3,4 @@
+ bar
+ baz
+ baz
++boing
+DIFF
+            , $builder->generateUnifiedDiff());
+    }
+
+    public function testAppendLineAtEndWithSingleBlankLine()
+    {
+        $builder = new PatchBuilder("foo\nfoo\nbar\nbaz\nbaz\n");
+        $builder->appendToLine(5, array("boing"));
+
+        $this->assertEquals(<<<DIFF
+@@ -3,3 +3,4 @@
+ bar
+ baz
+ baz
++boing
+DIFF
+            , $builder->generateUnifiedDiff());
+    }
 }


### PR DESCRIPTION
Outputed diff has a single blank line at end, so patch command results in "with fuzz xxx" .
