### PR TITLE
Fix #32, change adapter for TokenReflectinoAnalysis

### DIFF
--- a/features/optimize_use.feature
+++ b/features/optimize_use.feature
@@ -47,4 +47,38 @@ Feature: Optimize use
 
                      return $service;
             """
+    Scenario: Organize use for file without namespace and other uses
+        Given a PHP File named "src/Foo.php" with:
+            """
+            <?php
 
+            class Foo
+            {
+                public function operation()
+                {
+                    return new \Bar\Qux\Adapter();
+                }
+            }
+            """
+        When I use refactoring "optimize-use" with:
+            | arg       | value       |
+            | file      | src/Foo.php |
+        Then the PHP File "src/Foo.php" should be refactored:
+            """
+            --- a/vfs://project/src/Foo.php
+            +++ b/vfs://project/src/Foo.php
+            @@ -1,4 +1,6 @@
+             <?php
+
+            +use Bar\Qux\Adapter;
+            +
+             class Foo
+             {
+            @@ -5,5 +5,5 @@
+                 public function operation()
+                 {
+            -        return new \Bar\Qux\Adapter();
+            +        return new Adapter();
+                 }
+             }
+            """

--- a/src/main/QafooLabs/Refactoring/Adapters/TokenReflection/StaticCodeAnalysis.php
+++ b/src/main/QafooLabs/Refactoring/Adapters/TokenReflection/StaticCodeAnalysis.php
@@ -22,6 +22,7 @@ use QafooLabs\Refactoring\Domain\Model\PhpName;
 
 use TokenReflection\Broker;
 use TokenReflection\Broker\Backend\Memory;
+use TokenReflection\ReflectionNamespace;
 
 class StaticCodeAnalysis extends CodeAnalysis
 {
@@ -143,11 +144,12 @@ class StaticCodeAnalysis extends CodeAnalysis
 
         $file = $this->broker->processString($file->getCode(), $file->getRelativePath(), true);
         foreach ($file->getNamespaces() as $namespace) {
+            $noNamespace = ReflectionNamespace::NO_NAMESPACE_NAME === $namespace->getName();
             foreach ($namespace->getClasses() as $class) {
                 $classes[] = new PhpClass(
                     PhpName::createDeclarationName($class->getName()),
                     $class->getStartLine(),
-                    $namespace->getStartLine()
+                    $noNamespace ? 0 : $namespace->getStartLine()
                 );
             }
         }

--- a/src/test/QafooLabs/Refactoring/Adapters/TokenReflection/StaticCodeAnalysisTest.php
+++ b/src/test/QafooLabs/Refactoring/Adapters/TokenReflection/StaticCodeAnalysisTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace QafooLabs\Refactoring\Adapters\TokenReflection;
+
+use PHPUnit_Framework_TestCase;
+use QafooLabs\Refactoring\Domain\Model\File;
+
+class StaticCodeAnalysisTest extends PHPUnit_Framework_TestCase 
+{
+    public function testNamespaceDeclarationForFileWithoutNamespace_isInLine0()
+    {
+        $file = new File('without-namespace.php', <<<'PHP'
+<?php
+
+class WithoutNamespace
+{
+
+}
+PHP
+        );
+
+        $analysis = new StaticCodeAnalysis();
+        $classes = $analysis->findClasses($file);
+        $class = $classes[0];
+
+        $this->assertEquals(0, $class->namespaceDeclarationLine(), 'namespace declaration line for file without namespace');
+    }
+}


### PR DESCRIPTION
Unfortunately there was a bug/feature in the TokenReflectionAnalysis. When a file without a namespace token is given, the namespaceDeclarationLine is set to the line of the first class token. I found this very unintuitive and changed our adapter for this case to return the namespaceDeclarationLine as 0