### PR TITLE
Extract method works properly with code indented more than one level

### DIFF
--- a/features/extract_method.feature
+++ b/features/extract_method.feature
@@ -265,3 +265,43 @@ Feature: Extract Method
                  }
              }
             """
+
+    Scenario: Extract method from inside a block
+        Given a PHP File named "src/ExtractMethodFromBlock.php" with:
+            """
+            <?php
+            class ExtractMethodFromBlock
+            {
+                public function operation()
+                {
+                    for ($i=0; $i<5; $i++) {
+                        echo "Hello World";
+                    }
+                }
+            }
+            """
+        When I use refactoring "extract-method" with:
+            | arg       | value       |
+            | file      | src/ExtractMethodFromBlock.php |
+            | range     | 7-7         |
+            | newmethod | hello       |
+        Then the PHP File "src/ExtractMethodFromBlock.php" should be refactored:
+            """
+            --- a/vfs://project/src/ExtractMethodFromBlock.php
+            +++ b/vfs://project/src/ExtractMethodFromBlock.php
+            @@ -4,7 +4,12 @@
+                 public function operation()
+                 {
+                     for ($i=0; $i<5; $i++) {
+            -            echo "Hello World";
+            +            $this->hello();
+                     }
+                 }
+            +
+            +    private function hello()
+            +    {
+            +        echo "Hello World";
+            +    }
+             }
+
+            """

--- a/src/main/QafooLabs/Refactoring/Adapters/PatchBuilder/PatchBuffer.php
+++ b/src/main/QafooLabs/Refactoring/Adapters/PatchBuilder/PatchBuffer.php
@@ -11,7 +11,6 @@
  * to kontakt@beberlei.de so I can send you a copy immediately.
  */
 
-
 namespace QafooLabs\Refactoring\Adapters\PatchBuilder;
 
 use QafooLabs\Refactoring\Domain\Model\EditorBuffer;
@@ -28,6 +27,11 @@ class PatchBuffer implements EditorBuffer
     public function __construct(PatchBuilder $builder)
     {
         $this->builder = $builder;
+    }
+
+    public function getLines(LineRange $range)
+    {
+        return $this->builder->getOriginalLines($range->getStart(), $range->getEnd());
     }
 
     public function replace(LineRange $range, array $newLines)

--- a/src/main/QafooLabs/Refactoring/Adapters/PatchBuilder/PatchBuilder.php
+++ b/src/main/QafooLabs/Refactoring/Adapters/PatchBuilder/PatchBuilder.php
@@ -50,6 +50,15 @@ class PatchBuilder
         $this->path = $path;
     }
 
+    public function getOriginalLines($start, $end)
+    {
+        return array_slice(
+            $this->buffer->getOriginalContents(),
+            $start - 1,
+            $end - $start + 1
+        );
+    }
+
     /**
      * Change Token in given line from old to new.
      *
@@ -74,7 +83,6 @@ class PatchBuilder
             array($newLine)
         );
     }
-
 
     /**
      * Append new lines to an original line of the file.

--- a/src/main/QafooLabs/Refactoring/Domain/Model/EditingAction/ReplaceWithMethodCall.php
+++ b/src/main/QafooLabs/Refactoring/Domain/Model/EditingAction/ReplaceWithMethodCall.php
@@ -6,6 +6,8 @@ use QafooLabs\Refactoring\Domain\Model\EditingAction;
 use QafooLabs\Refactoring\Domain\Model\EditorBuffer;
 use QafooLabs\Refactoring\Domain\Model\MethodSignature;
 use QafooLabs\Refactoring\Domain\Model\LineRange;
+use QafooLabs\Refactoring\Domain\Model\LineCollection;
+use QafooLabs\Refactoring\Domain\Model\IndentationDetector;
 
 class ReplaceWithMethodCall implements EditingAction
 {
@@ -27,12 +29,23 @@ class ReplaceWithMethodCall implements EditingAction
 
     public function performEdit(EditorBuffer $buffer)
     {
-        $buffer->replace($this->range, array($this->getIndent() . $this->getMethodCall()));
+        $extractedCode = $buffer->getLines($this->range);
+
+        $buffer->replace($this->range, array($this->getIndent($extractedCode) . $this->getMethodCall()));
     }
 
-    private function getIndent()
+    /**
+     * @param string[] $lines
+     *
+     * @return string
+     */
+    private function getIndent(array $lines)
     {
-        return '        ';
+        $detector = new IndentationDetector(
+            LineCollection::createFromArray($lines)
+        );
+
+        return str_repeat(' ', $detector->getFirstLineIndentation());
     }
 
     private function getMethodCall()

--- a/src/main/QafooLabs/Refactoring/Domain/Model/EditorBuffer.php
+++ b/src/main/QafooLabs/Refactoring/Domain/Model/EditorBuffer.php
@@ -20,6 +20,15 @@ namespace QafooLabs\Refactoring\Domain\Model;
 interface EditorBuffer
 {
     /**
+     * Return the given range of lines from the buffer.
+     *
+     * @param  LineRange $range
+     *
+     * @return string[]
+     */
+    public function getLines(LineRange $range);
+
+    /**
      * Replace LineRange with new lines.
      *
      * @param LineRange $range

--- a/src/test/QafooLabs/Refactoring/Adapters/PatchBuilder/PatchBuilderTest.php
+++ b/src/test/QafooLabs/Refactoring/Adapters/PatchBuilder/PatchBuilderTest.php
@@ -200,4 +200,12 @@ DIFF;
 DIFF;
         $this->assertEquals($expected, $this->builder->generateUnifiedDiff());
     }
+
+    public function testGetOriginalLines()
+    {
+        $this->assertEquals(
+            array('line4', 'line5', 'line6'),
+            $this->builder->getOriginalLines(4, 6)
+        );
+    }
 }

--- a/src/test/QafooLabs/Refactoring/Domain/Model/EditingSessionTest.php
+++ b/src/test/QafooLabs/Refactoring/Domain/Model/EditingSessionTest.php
@@ -1,4 +1,15 @@
 <?php
+/**
+ * Qafoo PHP Refactoring Browser
+ *
+ * LICENSE
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this package in the file LICENSE.txt.
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to kontakt@beberlei.de so I can send you a copy immediately.
+ */
 
 namespace QafooLabs\Refactoring\Domain\Model;
 


### PR DESCRIPTION
Extract method was messing up the extracted method if the code being extracted was indented more than 4 spaces. 

Also the method call to the extracted method was not indented correctly.

This PR fixes both these issues.

Unit tests & acceptance tests are included.

PS: For some reason 2 scenarios are failing the the Fix Class Names feature but there were failing before I started working so I'm assuming that they either are currently broken in the repo or something in my environment?