### PR TITLE
Stop rename local variables corrupting variables with similar names

### DIFF
--- a/features/rename_local_variable.feature
+++ b/features/rename_local_variable.feature
@@ -48,3 +48,45 @@ Feature: Rename Local Variable
                  }
              }
             """
+
+    Scenario: Rename variable in method other other similarly named variables on same line
+        Given a PHP File named "src/SimilarVariableName.php" with:
+            """
+            <?php
+            class SimilarVariableName
+            {
+                public function operation()
+                {
+                    $var = 2;
+
+                    $varsecond = 5;
+
+                    return $var + $varsecond;
+                }
+            }
+            """
+        When I use refactoring "rename-local-variable" with:
+            | arg       | value                       |
+            | file      | src/SimilarVariableName.php |
+            | line      | 6                           |
+            | name      | var                         |
+            | new-name  | number                      |
+        Then the PHP File "src/SimilarVariableName.php" should be refactored:
+            """
+            --- a/vfs://project/src/SimilarVariableName.php
+            +++ b/vfs://project/src/SimilarVariableName.php
+            @@ -3,10 +3,10 @@
+             {
+                 public function operation()
+                 {
+            -        $var = 2;
+            +        $number = 2;
+       
+                     $varsecond = 5;
+       
+            -        return $var + $varsecond;
+            +        return $number + $varsecond;
+                 }
+             }
+
+            """


### PR DESCRIPTION
This PR fixes an issue where when renaming a local variable which appears on the same line as another variable which starts with the name of the variable being changed, then it corrupts the name of the other variable.

e.g. In the following situation

```php
class X
{
    public function methodY()
    {
        $foo = 7;
        $foobaz = 5;

        $foo = $foo + $foobaz;
    }
}
```

If you use the rename local variable function to rename `$foo` to `$bar` then `$foobaz` on the line which says `$foo = $foo + $foobaz;` will mistakenly be renamed to `$barbaz`