### PR TITLE
Fix: make PatchBuilder->changeToken() case sensitive

### DIFF
--- a/src/main/QafooLabs/Refactoring/Adapters/PatchBuilder/PatchBuilder.php
+++ b/src/main/QafooLabs/Refactoring/Adapters/PatchBuilder/PatchBuilder.php
@@ -64,7 +64,7 @@ class PatchBuilder
         $newLine = $this->buffer->getLine($this->createLineNumber($originalLine));
 
         $newLine = preg_replace(
-            '!(^|[^a-z0-9])(' . preg_quote($oldToken) . ')([^a-z0-9]|$)!i',
+            '!(^|[^a-z0-9])(' . preg_quote($oldToken) . ')([^a-z0-9]|$)!',
             '\1' . $newToken . '\3',
             $newLine
         );

--- a/src/test/QafooLabs/Refactoring/Adapters/PatchBuilder/PatchBuilderTest.php
+++ b/src/test/QafooLabs/Refactoring/Adapters/PatchBuilder/PatchBuilderTest.php
@@ -42,6 +42,22 @@ class PatchBuilderTest extends \PHPUnit_Framework_TestCase
  line7
 
 DIFF;
+
+        $this->assertEquals($expected, $this->builder->generateUnifiedDiff());
+    }
+
+    public function testChangeIsCaseSensitive() {
+        $this->builder = new PatchBuilder('$bar = new Bar();');
+        $this->builder->changeToken(1, 'Bar', 'Foo');
+
+        $expected = <<<DIFF
+--- a/
++++ b/
+@@ -1,1 +1,1 @@
+-\$bar = new Bar();
++\$bar = new Foo();
+
+DIFF;
         $this->assertEquals($expected, $this->builder->generateUnifiedDiff());
     }
 


### PR DESCRIPTION
`EditorBuffer::replaceString` and `PatchBuilder::changeToken` should be case sensitive. 

Otherwise 
```
$bar = new Bar();
```
will be changed to 
```
$Foo = new Foo();
```

during fix-class-names refactoring. 
