### PR TITLE
Allow stdin input for single file refactors

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Based on data from these sources the Refactoring Browser consists of two distinc
 
 ## Install & Basic Usage
 
-[Download PHAR](https://github.com/QafooLabs/php-refactoring-browser/releases)
+[Download PHAR](https://github.com/FlickerBean/php-refactoring-browser/releases/tag/v0.1.1)
 
 The refactoring browser is used with:
 

--- a/src/main/QafooLabs/Refactoring/Adapters/Symfony/Commands/ConvertLocalToInstanceVariableCommand.php
+++ b/src/main/QafooLabs/Refactoring/Adapters/Symfony/Commands/ConvertLocalToInstanceVariableCommand.php
@@ -65,7 +65,20 @@ HELP
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $file = File::createFromPath($input->getArgument('file'), getcwd());
+        $filename = $input->getArgument('file');
+        if ('-' == $filename) {
+            $filename = false;
+            $contents = '';
+            while (!feof(STDIN)) {
+                $contents .= fread(STDIN, 1024);
+            }
+        }
+        if ($filename) {
+            $file = File::createFromPath($filename, getcwd());
+        } else {
+            $file = File::createFromContents($contents, getcwd());
+        }
+
         $line = (int)$input->getArgument('line');
         $variable = new Variable($input->getArgument('variable'));
 

--- a/src/main/QafooLabs/Refactoring/Adapters/Symfony/Commands/ExtractMethodCommand.php
+++ b/src/main/QafooLabs/Refactoring/Adapters/Symfony/Commands/ExtractMethodCommand.php
@@ -72,7 +72,20 @@ HELP
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $file = File::createFromPath($input->getArgument('file'), getcwd());
+        $filename = $input->getArgument('file');
+        if ('-' == $filename) {
+            $filename = false;
+            $contents = '';
+            while (!feof(STDIN)) {
+                $contents .= fread(STDIN, 1024);
+            }
+        }
+        if ($filename) {
+            $file = File::createFromPath($filename, getcwd());
+        } else {
+            $file = File::createFromContents($contents, getcwd());
+        }
+
         $range = LineRange::fromString($input->getArgument('range'));
         $newMethodName = $input->getArgument('newmethod');
 

--- a/src/main/QafooLabs/Refactoring/Adapters/Symfony/Commands/OptimizeUseCommand.php
+++ b/src/main/QafooLabs/Refactoring/Adapters/Symfony/Commands/OptimizeUseCommand.php
@@ -72,7 +72,19 @@ HELP
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $file = File::createFromPath($input->getArgument('file'), getcwd());
+        $filename = $input->getArgument('file');
+        if ('-' == $filename) {
+            $filename = false;
+            $contents = '';
+            while (!feof(STDIN)) {
+                $contents .= fread(STDIN, 1024);
+            }
+        }
+        if ($filename) {
+            $file = File::createFromPath($filename, getcwd());
+        } else {
+            $file = File::createFromContents($contents, getcwd());
+        }
 
         $codeAnalysis = new StaticCodeAnalysis();
         $editor = new PatchEditor(new OutputPatchCommand($output));

--- a/src/main/QafooLabs/Refactoring/Adapters/Symfony/Commands/RenameLocalVariableCommand.php
+++ b/src/main/QafooLabs/Refactoring/Adapters/Symfony/Commands/RenameLocalVariableCommand.php
@@ -64,7 +64,20 @@ HELP
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $file = File::createFromPath($input->getArgument('file'), getcwd());
+        $filename = $input->getArgument('file');
+        if ('-' == $filename) {
+            $filename = false;
+            $contents = '';
+            while (!feof(STDIN)) {
+                $contents .= fread(STDIN, 1024);
+            }
+        }
+        if ($filename) {
+            $file = File::createFromPath($filename, getcwd());
+        } else {
+            $file = File::createFromContents($contents, getcwd());
+        }
+
         $line = (int)$input->getArgument('line');
         $name = new Variable($input->getArgument('name'));
         $newName = new Variable($input->getArgument('new-name'));

--- a/src/main/QafooLabs/Refactoring/Domain/Model/File.php
+++ b/src/main/QafooLabs/Refactoring/Domain/Model/File.php
@@ -20,6 +20,7 @@ class File
 {
     private $relativePath;
     private $code;
+    private $temp_file;
 
     /**
      * @param string $path
@@ -44,6 +45,22 @@ class File
 
         return new self($relativePath, $code);
     }
+
+    /**
+     * @param mixed $content
+     * @param mixed $workingDirectory
+     *
+     * @return File
+     */
+    public static function createFromContents($content, $workingDirectory)
+    {
+        $temp = tmpfile();
+        $metaDatas = stream_get_meta_data($temp);
+        $tmpFilename = $metaDatas['uri'];
+        fwrite($temp, $content);
+        return File::createFromPath($tmpFilename, $workingDirectory);
+    }
+
 
     public function __construct($relativePath, $code)
     {

--- a/src/main/QafooLabs/Refactoring/Domain/Model/File.php
+++ b/src/main/QafooLabs/Refactoring/Domain/Model/File.php
@@ -55,10 +55,19 @@ class File
     public static function createFromContents($content, $workingDirectory)
     {
         $temp = tmpfile();
-        $metaDatas = stream_get_meta_data($temp);
-        $tmpFilename = $metaDatas['uri'];
+        $meta_datas = stream_get_meta_data($temp);
+        $tmp_filename = $meta_datas['uri'];
         fwrite($temp, $content);
-        return File::createFromPath($tmpFilename, $workingDirectory);
+
+        // Now we move the file to prevent it being instantly deleted at the
+        // end of the script. This allows piping it to 'patch' for instance,
+        // which requires the original file.
+        $new_tmp_filename = $tmp_filename.'1';
+        if (!rename($tmp_filename, $new_tmp_filename)) {
+            throw new RuntimeException("Could not move temporary file " . $tmp_filename);
+        }
+
+        return File::createFromPath($new_tmp_filename, $workingDirectory);
     }
 
 


### PR DESCRIPTION
Allowing stdin input has many uses and is, in my opinion essential.

I'm not familiar with the codebase, but I came up with these changes to support stdin.

Example of use:
`$ cat home.php | php refactor.phar extract-method - 7-7 myNewFunction`
(obviously this isn't a great example of a use case)

Replacing the filename parameter with `-` will tell refactor.phar to use stdin as the file contents instead of a specific file.

As most commands have a dependency on the File class, it will create a tmpfile() with the stdin contents, and then create a File object from the temporary file. I've added a static File::createFromContents() function to facilitate this.

Use cases are numerous, but my specific use case/reason for implementation is for the vim-php-refactoring plugin (i've also forked to support this change). Which has multiple restrictions thrust upon it due to php-refactoring-browser not supporting stdin input.

Example:
`:%!php refactor.phar extract-method - 7-7 myNewFunction | patch --silent --ouput=- --dir="/tmp"`

This allows on-the-fly refactoring of modified vim buffers, without worrying about loosing unsaved buffer changes, or directly modifying and having the reload the file on disk. It makes the whole experience much more seamless.
